### PR TITLE
feat: add alt header

### DIFF
--- a/user/pages/04.certification/docs.md
+++ b/user/pages/04.certification/docs.md
@@ -1,5 +1,6 @@
 ---
 title: Certification
+altTitle: Get certified
 taxonomy:
     category: docs
 child_type: docs

--- a/user/themes/centra/templates/partials/sidenav.html.twig
+++ b/user/themes/centra/templates/partials/sidenav.html.twig
@@ -10,7 +10,7 @@
     {% set current_page = p.active ? ' active' : '' %}
     <li class="dd-item{{ parent_page }}{{ current_page }}" data-nav-id="{{ p.route }}">
         <a href="{{ p.url }}" {% if p.header.class %}class="{{ p.header.class }}"{% endif %} class="{% if p.active or p.activeChild %} navigation__item--active {% endif %}">
-            <span>{{ p.menu }}</span>
+            <span>{{ p.header.altTitle ? p.header.altTitle : p.menu }}</span>
             <span class="navigation__item-arrow {% if p.active or p.activeChild %} navigation__item-arrow--active {% endif %}"></span>
         </a>
         {% if p.activeChild or p.active %}

--- a/user/themes/centra/templates/partials/topnav.html.twig
+++ b/user/themes/centra/templates/partials/topnav.html.twig
@@ -13,7 +13,7 @@
                     {% for page in pages.children.visible %}
                         <li class="navigation__item">
                             <a href="{{ page.url }}" class="navigation-item__link {% if page.active or page.activeChild %} navigation-item__link--active {% endif %}">
-                                {{ page.menu }}
+                                {{ page.header.altTitle ? page.header.altTitle : page.menu }}
                             </a>
                             <span class="navigation-item__dot"/>         
                         </li>


### PR DESCRIPTION
Add support for alternative title.
Users can now use `altTitle` property in file header to set different page name in the menu.