### PR TITLE
feat: add cover page

### DIFF
--- a/user/pages/01.guides/05.orderflow/docs.md
+++ b/user/pages/01.guides/05.orderflow/docs.md
@@ -1,5 +1,6 @@
 ---
 title: Order flow
+excerpt: Check out the basic order flow as seen in Centra backend.
 taxonomy:
     category: docs
 ---

--- a/user/pages/01.guides/cover.md
+++ b/user/pages/01.guides/cover.md
@@ -5,8 +5,4 @@ taxonomy:
 child_type: docs
 ---
 
-### Chapter 1
-
-# Guides
-
 Discover the **basic** principles

--- a/user/themes/centra/templates/cover.html.twig
+++ b/user/themes/centra/templates/cover.html.twig
@@ -1,0 +1,27 @@
+{% extends 'partials/base.html.twig' %}
+
+{% block beforecontent %}
+    {% include 'partials/sidenav.html.twig' %}
+{% endblock %}
+{% block content %}
+    <div class="main__content">
+        {% include 'partials/content.html.twig' %}
+        <p>Section contents:</p>
+        {% for p in page.children.visible %}
+            <article>
+                <h2>{{ p.header.altTitle ? p.header.altTitle : p.menu }}</h2>
+                <p>{{ p.header.excerpt ? p.header.excerpt : p.content|truncate(230) }}</p>
+                <a href="{{ p.url }}">Read more</a>
+            </article>
+        {% endfor %}
+        {% include 'partials/arrownav.html.twig' %}
+    </div>
+{% endblock %}
+{% block aftercontent %}
+    <div class="page-toc__toggle-wrapper">
+        <div id="toc">
+            <button class="page-toc__toggle" onclick="togglePageSearch()"><img src="{{ url("theme://images/img/toc-icon.svg")}}"/></button>
+            {% include 'partials/toc.html.twig' %}
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46019258/60722286-c1317000-9f30-11e9-8fed-48277da8cc8a.png)

Add cover page template for listing contents of the section.
The cover page automatically adds the short description of each section if no `excerpt` is defined in header section of the document.