### PR TITLE
Moving Order-api  and Subscription API from old dev

### DIFF
--- a/pages/05.api-references/02.shop-api/01.api-reference/01.get_brands/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/01.get_brands/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Brands
-altTitle: GET Brands
+title: Shop API - Get Brands
+altTitle: Get Brands
 excerpt: Fetching a single or multiple brands
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/02.get-campaign-sites/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/02.get-campaign-sites/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Campaign Sites
-altTitle: GET Campaign Sites
+title: Shop API - Get Campaign Sites
+altTitle: Get Campaign Sites
 excerpt: Fetching a single or multiple campaign sites.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/03.get-campaigns/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/03.get-campaigns/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Campaigns
-altTitle: GET Campaigns
+title: Shop API - Get Campaigns
+altTitle: Get Campaigns
 excerpt: Fetching a single or multiple campaigns.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/04.get-categories/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/04.get-categories/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Categories
-altTitle: GET Categories
+title: Shop API - Get Categories
+altTitle: Get Categories
 excerpt: Fetching a single or multiple categories.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/05.get-collections/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/05.get-collections/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Collections
-altTitle: GET Collections
+title: Shop API - Get Collections
+altTitle: Get Collections
 excerpt: Fetching a single or multiple collections.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/06.get-measurement-charts/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/06.get-measurement-charts/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Measurement Charts
-altTitle: GET Measurement Charts
+title: Shop API - Get Measurement Charts
+altTitle: Get Measurement Charts
 excerpt: Fetching a single or multiple collections.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/07.get-product-ids/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/07.get-product-ids/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Products IDs
-altTitle: GET Products IDs
+title: Shop API - Get Products IDs
+altTitle: Get Products IDs
 excerpt: Fetching a list of products ids.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/08.get-products/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/08.get-products/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Products
-altTitle: GET Products
+title: Shop API - Get Products
+altTitle: Get Products
 excerpt: Fetching a single or multiple products.
 taxonomy:
   category: docs

--- a/pages/05.api-references/02.shop-api/01.api-reference/09.get-products-filtered/docs.md
+++ b/pages/05.api-references/02.shop-api/01.api-reference/09.get-products-filtered/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Shop API - GET Filtered Products
-altTitle: GET Filtered Products
+title: Shop API - Get Filtered Products
+altTitle: Get Filtered Products
 excerpt: Fetching a list products based on filters.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/104.get-orders/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/104.get-orders/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Orders
-altTitle: GET Orders
+title: Order API - Get Orders
+altTitle: Get Orders
 excerpt: Fetching the orders allowed for the plugin being set up.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/107.get-shipments/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/107.get-shipments/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Shipments
-altTitle: GET Shipments
+title: Order API - Get Shipments
+altTitle: Get Shipments
 excerpt: Fetching all Good to Go-shipments that are not sent.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/202.get-returns/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/202.get-returns/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Returns
-altTitle: GET Returns
+title: Order API - Get Returns
+altTitle: Get Returns
 excerpt: Fetching all returns.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/301.get-products/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/301.get-products/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Products
-altTitle: GET Products
+title: Order API - Get Products
+altTitle: Get Products
 excerpt: Returning product data from Centra with categories.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/302.get-stock/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/302.get-stock/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Stock
-altTitle: GET Stock
+title: Order API - Get Stock
+altTitle: Get Stock
 excerpt: Returning product data from Centra with stock info
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/402.get-customer/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/402.get-customer/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Customer
-altTitle: GET Customer
+title: Order API - Get Customer
+altTitle: Get Customer
 excerpt: Returning customer by specified ID
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/502.get-supplier-order/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/502.get-supplier-order/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Supplier Order
-altTitle: GET Supplier Order
+title: Order API - Get Supplier Order
+altTitle: Get Supplier Order
 excerpt: Listing the products inside a supplier order.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/504.get-supplier-delivery/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/504.get-supplier-delivery/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Supplier Delivery
-altTitle: GET Supplier Delivery
+title: Order API - Get Supplier Delivery
+altTitle: Get Supplier Delivery
 excerpt: Getting the incoming and not accepted deliveries that are connected to the warehouse this plugin is connected to.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/505.get-supplier-delivery-details/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/505.get-supplier-delivery-details/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Supplier Delivery Details
-altTitle: GET Supplier Delivery Details
+title: Order API - Get Supplier Delivery Details
+altTitle: Get Supplier Delivery Details
 excerpt: Getting the incoming and not accepted deliveries that are connected to the warehouse this plugin is connected to.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/603.get-voucher/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/603.get-voucher/docs.md
@@ -1,6 +1,6 @@
 ---
-title: Order API - GET Voucher
-altTitle: GET Voucher
+title: Order API - Get Voucher
+altTitle: Get Voucher
 excerpt: Fetching active/inactive voucher by specified ID.
 taxonomy:
   category: docs

--- a/pages/05.api-references/04.order-api/01.api-reference/701.list-custumers/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/701.list-custumers/docs.md
@@ -1,0 +1,125 @@
+---
+title: Order API - List customers
+altTitle: List customers
+excerpt: Return list of the customers.
+taxonomy:
+  category: docs
+---
+
+# List Customers
+
+```text
+GET *base*/customers
+```
+
+Return list of the customers.
+
+## Parameters
+
+[parameter data="limit" datatype="int" isRequired=false sublevel=1]
+Limit amount of customers returned.
+[/parameter]
+
+[parameter data="offset" datatype="int" isRequired=false sublevel=1]
+Offset how far in to start returning customers.
+[/parameter]
+
+[parameter data="email" datatype="string" isRequired=false sublevel=1]
+Return a specific customer.
+[/parameter]
+
+[parameter data="created" datatype="date/datetime" isRequired=false sublevel=1]
+Get all customers added after a certain date. Allowed formats ``YYYY-mm-dd`` and ``YYYY-mm-dd HH:MM:SS``. Timezone is system-wide and decided by the company using Centra.
+[/parameter]
+
+[parameter data="modified" datatype="date/datetime" isRequired=false sublevel=1]
+Get all customers modified after a certain date. Allowed formats ``YYYY-mm-dd`` and ``YYYY-mm-dd HH:MM:SS``. Timezone is system-wide and decided by the company using Centra.
+[/parameter]
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+   GET <base>/customers?limit=5&offset=5 HTTP/1.1
+```
+
+<!--
+```eval_rst
+.. _order-api-list-customers-response:
+```
+-->
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="customers" datatype="array" isRequired=required sublevel=1]
+Array of customers returned. 
+[/parameter]
+
+
+## Response example
+
+```json
+   {
+          "status": "ok",
+          "customers": [
+              {
+                  "customerId": "1",
+                  "email": "max.buch@example.com",
+                  "firstName": "Max",
+                  "lastName": "Buch",
+                  "address1": "",
+                  "address2": "",
+                  "zipCode": "",
+                  "city": "",
+                  "state": "",
+                  "country": "SE",
+                  "phoneNumber": "",
+                  "newsletter": true,
+                  "gender": "",
+                  "registered": false,
+                  "consents": [
+                      {
+                          "key": "test_key1",
+                          "name": "Consent1",
+                          "consented": false,
+                          "text": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley ",
+                          "language": "",
+                          "version": "",
+                          "created": "2018-03-15 20:42:59",
+                          "modified": "2018-03-15 20:42:59"
+                      }
+                  ],
+                  "created": "2018-03-15 20:42:59",
+                  "modified": "2018-03-15 20:42:59"
+              },
+              {
+                  "customerId": "6",
+                  "email": "felix.parker@example.com",
+                  "firstName": "Felix",
+                  "lastName": "Parker",
+                  "address1": "",
+                  "address2": "Forest st. 102",
+                  "zipCode": "95131",
+                  "city": "San Jose",
+                  "state": "CA",
+                  "country": "US",
+                  "phoneNumber": "",
+                  "newsletter": false,
+                  "gender": "",
+                  "registered": true,
+                  "consents": [],
+                  "created": "2018-03-15 20:42:59",
+                  "modified": "2018-03-15 20:42:59"
+              }
+          ]
+      }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/702.list-supplier-deliveries/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/702.list-supplier-deliveries/docs.md
@@ -1,0 +1,114 @@
+---
+title: Order API - List supplier deliveries
+altTitle: List supplier deliveries
+excerpt: Get the incoming and not accepted deliveries that are connected to the warehouse this plugin is connected to.
+taxonomy:
+  category: docs
+---
+
+# List supplier deliveries
+
+```text
+GET *base*/supplier-deliveries
+```
+
+Get the incoming and not accepted deliveries that are connected to the warehouse this plugin is connected to.
+
+Deliveries will be listed when these requirements are fulfilled:
+
+* Delivery created on a confirmed Supplier Order.
+* Supplier order has the Preferred Warehouse set to the "Supplier Delivery Warehouse" in the Plugin.
+* Delivery is not accepted yet.
+* Delivery has items in it.
+
+## Parameters
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+   GET <base>/supplier-deliveries HTTP/1.1
+```
+
+<!--
+```eval_rst
+.. _order-api-list-supplier-deliveries-response:
+```
+-->
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="deliveries" datatype="array" isRequired=required sublevel=1]
+Array of deliveries returned
+[/parameter]
+
+[parameter data="id" datatype="string" sublevel=2]
+Internal ID for the supplier order delivery.
+[/parameter]
+
+[parameter data="deliveryId" datatype="string" sublevel=2]
+ID of the supplier order delivery. This is the ID communicated externally.
+[/parameter]
+
+[parameter data="orderId" datatype="string" sublevel=2]
+ID of the supplier order.
+[/parameter]
+
+[parameter data="supplierCountry" datatype="string" sublevel=2]
+ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc).
+[/parameter]
+
+[parameter data="created" datatype="datetime" sublevel=2]
+The date this supplier order delivery was created.
+[/parameter]
+
+[parameter data="ETA" datatype="datetime" sublevel=2]
+Estimated time of arrival to the warehouse. This will be used to calculate what orders that should be automatically connected to this specific delivery.
+[/parameter]
+
+[parameter data="ETD" datatype="datetime" sublevel=2]
+Estimated time of delivery for the customer.
+[/parameter]
+
+## Response example
+
+```json
+   {
+     "status": "ok",
+     "deliveries": [
+       {
+         "id": "364",
+         "orderId": "957",
+         "deliveryId": "957-1",
+         "supplierName": "Falca",
+         "supplierCountry": "ES",
+         "created": "2019-01-28 01:15",
+         "ETD": "2019-03-31 15:15",
+         "ETA": "2019-04-05 20:15",
+         "message": "Text entered by centra admin",
+         "productsQty": 20000
+       },
+       {
+         "id": "365",
+         "orderId": "957",
+         "deliveryId": "957-2",
+         "supplierName": "Falca",
+         "supplierCountry": "ES",
+         "created": "2019-01-28 01:15",
+         "ETD": "2019-03-31 15:15",
+         "ETA": "2019-04-05 20:15",
+         "message": "Text entered by centra admin",
+         "productsQty": 10000
+       }
+     ]
+   }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/703.list-supplier-orders/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/703.list-supplier-orders/docs.md
@@ -1,0 +1,100 @@
+---
+title: Order API - List supplier orders
+altTitle: List supplier orders
+excerpt: Get all confirmed supplier orders visible by the plugin.
+taxonomy:
+  category: docs
+---
+
+# List supplier orders
+
+```text
+GET *base*/supplier-orders
+```
+
+Get all confirmed supplier orders visible by the plugin.
+
+## Parameters
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+   GET <base>/supplier-orders HTTP/1.1
+```
+
+<!--
+```eval_rst
+.. _order-api-list-supplier-deliveries-response:
+```
+-->
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="orders" datatype="array" isRequired=required sublevel=1]
+Array of orders returned
+[/parameter]
+
+[parameter data="orderId" datatype="string" isRequired=true sublevel=2]
+ID of the supplier order.
+[/parameter]
+
+[parameter data="supplierCountry" datatype="string" sublevel=2]
+ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc).
+[/parameter]
+
+[parameter data="created" datatype="datetime" sublevel=2]
+The date this supplier order was created.
+[/parameter]
+
+[parameter data="ETA" datatype="datetime" sublevel=2]
+Estimated time of arrival to the warehouse. This will be used to calculate what orders that fits into a specific delivery window.
+[/parameter]
+
+[parameter data="ETD" datatype="datetime" sublevel=2]
+Estimated time of delivery for the customer.
+[/parameter]
+
+[parameter data="productsQty" datatype="int" sublevel=2]
+The total quantity of products in this supplier order.
+[/parameter]
+
+
+## Response example
+
+```json
+     {
+        "status": "ok",
+        "orders": [
+          {
+            "orderId": "957",
+            "supplierName": "Falca",
+            "supplierCountry": "ES",
+            "created": "2019-01-28 01:15",
+            "ETD": "2019-03-31 15:15",
+            "ETA": "2019-04-05 20:15",
+            "message": "Text entered by centra admin",
+            "productsQty": 20000
+          },
+          {
+            "orderId": "957",
+            "supplierName": "Falca",
+            "supplierCountry": "ES",
+            "created": "2019-01-28 01:15",
+            "ETD": "2019-03-31 15:15",
+            "ETA": "2019-04-05 20:15",
+            "message": "Text entered by centra admin",
+            "productsQty": 10000
+          }
+        ]
+      }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/801.update-customer/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/801.update-customer/docs.md
@@ -1,0 +1,140 @@
+---
+title: Order API - Update customer
+altTitle: Update customer
+excerpt: Update customer information.
+taxonomy:
+  category: docs
+---
+
+# Update customer
+
+```text
+PUT  *base*/customers/*customerId*
+```
+
+Update customer information.
+
+## Parameters
+
+[parameter data="customerId" datatype="int" isRequired=true sublevel=1]
+The ``customerID`` from :ref:`List customers <order-api-list-customers>`.
+[/parameter]
+
+[parameter data="firstName lastName ..." datatype="customer object"  sublevel=1]
+The customer object 
+[/parameter]
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+   PUT <base>/customers/4234 HTTP/1.1
+   Content-type: application/json
+
+   {
+       "firstName": "Benjamin",
+       "lastName": "Simon",
+       "address1": "",
+       "address2": "New Address2",
+       "zipCode": "10500",
+       "city": "BRIGHTON",
+       "country": "US",
+       "state": "CA",
+       "phoneNumber": "9004505123",
+       "gender": "",
+       "consents": [
+         {
+           "key": "firts_con",
+           "consented": true
+         },
+         {
+           "key": "second_con",
+           "consented": false,
+           "version": "1.0",
+           "language": "EN"
+         }
+       ]
+   }
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="customer" datatype="object" isRequired=true sublevel=1]
+Customer object. The customer object is explained in :ref:`Get Customer Parameters <order-api-get-customer-response>`.
+[/parameter]
+
+## Response example
+
+```json
+{
+       "status": "ok",
+       "customer": {
+           "customerId": "1",
+           "email": "benjamin.simon@example.com",
+           "firstName": "Benjamin",
+           "lastName": "Simon",
+           "address1": "",
+           "address2": "New Address2",
+           "zipCode": "10500",
+           "city": "BRIGHTON",
+           "state": "CA",
+           "country": "US",
+           "phoneNumber": "9004505123",
+           "newsletter": true,
+           "gender": "",
+           "registered": false,
+           "consents": [
+               {
+                   "key": "test_key1",
+                   "name": "Consent1",
+                   "consented": false,
+                   "text": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley ",
+                   "language": "",
+                   "version": "",
+                   "created": "2018-03-15 20:42:59",
+                   "modified": "2018-03-15 20:42:59"
+               },
+               {
+                   "key": "firts_con",
+                   "name": "",
+                   "consented": true,
+                   "text": "",
+                   "language": "",
+                   "version": "",
+                   "created": "2018-03-21 12:17:54",
+                   "modified": "2018-03-21 12:17:54"
+               },
+               {
+                   "key": "second_con",
+                   "name": "",
+                   "consented": false,
+                   "text": "",
+                   "language": "EN",
+                   "version": "1.0",
+                   "created": "2018-03-21 12:17:54",
+                   "modified": "2018-03-21 12:17:54"
+               }
+           ],
+           "created": "2018-03-15 20:42:59",
+           "modified": "2018-03-15 20:42:59"
+       }
+   }
+```
+
+## Error example
+
+```json
+{
+     "status": "no",
+     "msg": "The customer was not found."
+   }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/802.update-return/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/802.update-return/docs.md
@@ -1,0 +1,258 @@
+---
+title: Order API - Update return
+altTitle: Update return
+excerpt: Update information on Return.
+taxonomy:
+  category: docs
+---
+
+# Update return
+
+```text
+PUT  *base*/returns/*returnId*
+```
+
+Update information on Return.
+
+## Parameters
+
+[parameter data="returnId" datatype="string" isRequired=true sublevel=1]
+The ID from ``return`` when creating or updating a return.
+[/parameter]
+
+[parameter data="completed" datatype="boolean" isRequired=false sublevel=1]
+Set to `true`/`false` to change Return status to Complete/Pending.
+[/parameter]
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+   PUT <base>/returns/2 HTTP/1.1
+   Content-type: application/json
+   
+   {
+     "completed": true
+   }
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="return" datatype="object" isRequired=true sublevel=1]
+Object of fetched return.
+[/parameter]
+
+[parameter data="returnId" datatype="int" sublevel=2]
+ID of the return.
+[/parameter]
+
+[parameter data="completed" datatype="boolean" sublevel=2]
+Whether the return was completed or not.
+[/parameter]
+
+[parameter data="shipment" datatype="string" sublevel=2]
+Number of the shipment
+[/parameter]
+
+[parameter data="shipmentId" datatype="int" sublevel=2]
+ID of the shipment
+[/parameter]
+
+[parameter data="orderId" datatype="int" sublevel=2]
+ID of the order
+[/parameter]
+
+[parameter data="selectionId" datatype="string" sublevel=2]
+Selection ID of the order
+[/parameter]
+
+[parameter data="customerId" datatype="int" sublevel=2]
+Selection ID of the order
+[/parameter]
+
+[parameter data="date" datatype="datetime" sublevel=2]
+Date when return was created.
+[/parameter]
+
+[parameter data="returnCost" datatype="float" sublevel=2]
+Cost of the return.
+[/parameter]
+
+[parameter data="shippingCost" datatype="float" sublevel=2]
+Cost of shipping returned
+[/parameter]
+
+[parameter data="handlingCost" datatype="float" sublevel=2]
+Handling cost of the return.
+[/parameter]
+
+[parameter data="voucherValue" datatype="float" sublevel=2]
+Voucher value included in the return.
+[/parameter]
+
+[parameter data="taxValue" datatype="float" sublevel=2]
+Tax value of the return, zero if deducted.
+[/parameter]
+
+[parameter data="taxDeduction" datatype="float" sublevel=2]
+Tax deduction in the return.
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+Currency code in which order and also return was made.
+[/parameter]
+
+[parameter data="baseCurrency" datatype="string" sublevel=2]
+Code of the currency used as base in this store.
+[/parameter]
+
+[parameter data="baseCurrencyRate" datatype="float" sublevel=2]
+Exchange rate between ``currency`` and ``baseCurrency`` above.
+[/parameter]
+
+[parameter data="returnToStock" datatype="boolean" sublevel=2]
+Whether the return was marked as returned back to stock.
+[/parameter]
+
+[parameter data="comment" datatype="string" sublevel=2]
+Optional description added to the return.
+[/parameter]
+
+[parameter data="createdFrom" datatype="string" sublevel=2]
+Informs where this return originated, i.e. "Order API".
+[/parameter]
+
+[parameter data="products" datatype="array" sublevel=2]
+Products inside the return.
+[/parameter]
+
+[parameter data="returnLineId" datatype="int" sublevel=3]
+ID of the specific product item in this return.
+[/parameter]
+
+[parameter data="shipmentLineId" datatype="int" sublevel=3]
+ID of the related shipment line.
+[/parameter]
+
+[parameter data="orderLineId" datatype="int" sublevel=3]
+ID of the related order line.
+[/parameter]
+
+[parameter data="productId" datatype="int" sublevel=3]
+ID of the product.
+[/parameter]
+
+[parameter data="variantId" datatype="int" sublevel=3]
+ID of the product variant.
+[/parameter]
+
+[parameter data="productName" datatype="string" sublevel=3]
+Name of the product.
+[/parameter]
+
+[parameter data="productBrand" datatype="string" sublevel=3]
+Brand name of the product.
+[/parameter]
+
+[parameter data="variantName" datatype="string" sublevel=3]
+Name of the product variant.
+[/parameter]
+
+[parameter data="size" datatype="string" sublevel=3]
+Size description, if any.
+[/parameter]
+
+[parameter data="sku" datatype="string" sublevel=3]
+Product SKU.
+[/parameter]
+
+[parameter data="variantSku" datatype="string" sublevel=3]
+Product variant SKU.
+[/parameter]
+
+[parameter data="sizeSku" datatype="string" sublevel=3]
+Size SKU
+[/parameter]
+
+[parameter data="ean" datatype="string" sublevel=3]
+EAN of the item.
+[/parameter]
+
+[parameter data="quantity" datatype="int" sublevel=3]
+Quantity of this specific product item returned.
+[/parameter]
+
+[parameter data="price" datatype="float" sublevel=3]
+Unit price as seen on shipment
+[/parameter]
+
+[parameter data="msg" datatype="string" isRequired=false sublevel=1]
+If ``status`` returns ``no``, this value should send back a message why it failed.
+[/parameter]
+
+## Response example
+
+```json
+  {
+       "status": "ok",
+       "return": {
+           "returnId": 18,
+           "completed": false,
+           "shipment": "44-1",
+           "shipmentId": 1142,
+           "orderId": 44,
+           "selectionId": "be337d27e16564cadad0a340b8bc1fbe",
+           "customerId": 31,
+           "date": "2020-01-07 17:00:29",
+           "returnCost": 5,
+           "shippingCost": 5.55,
+           "handlingCost": 9,
+           "voucherValue": 0,
+           "taxValue": 21.91,
+           "taxDeduction": 0,
+           "currency": "SEK",
+           "baseCurrency": "SEK",
+           "baseCurrencyRate": 1,
+           "returnToStock": false,
+           "comment": null,
+           "createdFrom": "Order API",
+           "products": [
+               {
+                   "returnLineId": 17,
+                   "shipmentLineId": 2681,
+                   "orderLineId": 112,
+                   "productId": 7,
+                   "variantId": 2460,
+                   "productName": "Test Product STOCK",
+                   "productBrand": null,
+                   "variantName": null,
+                   "size": null,
+                   "sku": "TPSTOCK",
+                   "variantSku": "",
+                   "sizeSku": "",
+                   "ean": "StockTestEAN",
+                   "quantity": 1,
+                   "price": 100
+               }
+           ]
+       }
+   }
+```
+
+## Error example
+
+```json
+   {
+     "status": "no",
+     "msg": "Return with id=100500 does not exist"
+   }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/803.update-order/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/803.update-order/docs.md
@@ -1,0 +1,78 @@
+---
+title: Order API -  Update order
+altTitle: Update order
+excerpt: Update information on the order.
+taxonomy:
+  category: docs
+---
+
+# Update order
+
+```text
+PUT  *base*/orders
+```
+
+Update information on the order.
+
+## Parameters
+
+[parameter data="order" datatype="int" isRequired=true sublevel=1]
+Order ID to update
+[/parameter]
+
+[parameter data="internalComment" datatype="string" isRequired=false sublevel=1]
+Append some text to internal comment field.
+[/parameter]
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+   PUT <base>/orders HTTP/1.1
+   Content-type: application/json
+
+   {
+     "order": 83651,
+     "internalComment": "test"
+   }
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="order" datatype="int" isRequired=true sublevel=1]
+Order ID that was updated
+[/parameter]
+
+[parameter data="msg" datatype="string" isRequired=false sublevel=1]
+If ``status`` returns ``no``, this value should send back a message why it failed.
+[/parameter]
+
+## Response example
+
+```json
+  {
+     "status": "ok",
+     "order": 83651
+   }
+```
+
+
+
+## Error example
+
+```json
+{
+     "status": "no",
+     "msg": "order in wrong market",
+     "order": 83651
+   }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/804.update-shipment/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/804.update-shipment/docs.md
@@ -1,0 +1,205 @@
+---
+title: Order API -  Update shipment
+altTitle: Update shipment
+excerpt: This function is designed for creation and modification of new shipments.
+taxonomy:
+  category: docs
+---
+
+# Update shipment
+
+```text
+PUT  *base*/shipments/*shipmentId*
+```
+
+This will modify the products on the shipment, keeping the same `shipmentId`. This function is designed for creation and modification of new shipments, meaning it will *not* work on existing shipments which:
+
+* Have been shipped,
+* Have been captured or paid, or
+* Have any returns.
+
+The only exception to this rule is setting GTG (Good to Go) or setting serial numbers on serializable product lines. This you can do at any point.
+
+To be able to use this call, you need to create a shipment using `"capture": false` so the create shipment call is not trying to capture the money.
+
+[notice-box=alert]
+If the automatic capture when creating shipments is disabled, to avoid sending shipments that has not been captured you need to :ref:`Capture Shipment <order-api-capture-shipment>` before you ship it.
+[/notice-box]
+
+If you need to remove the shipment, use the [Delete Shipment](delete-shipment) method.
+
+## Parameters
+
+[parameter data="shipmentId" datatype="string" isRequired=true sublevel=1]
+The ID from ``shipment`` when creating or updating a shipment.
+[/parameter]
+
+[parameter data="gtg" datatype="boolean" isRequired=false sublevel=1]
+Default ``0``. Update shipment with Good to Go.
+[/parameter]
+
+[parameter data="products" datatype="object" isRequired=false sublevel=1]
+Key is ``lineID`` from the :ref:`Get orders response <get-orders-response>` and value is the ``quantity``.
+Example: ``{"products":{"1441":3}}`` will update a shipment to 3 products from item ``1441``.
+[/parameter]
+
+[parameter data="key in object" datatype="string" isRequired=true sublevel=2]
+``lineID`` from the :ref:`Get orders response <get-orders-response>` referring to a specific product item in the order.
+[/parameter]
+
+[parameter data="value in object" datatype="int" isRequired=true sublevel=2]
+Quantity of the item that should be set for the shipment.
+[/parameter]
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+
+```http
+     PUT <base>/shipments/23123 HTTP/1.1
+     Content-type: application/json
+  
+     {
+       "gtg":1,
+       "products": {
+         "43243": 1,
+         "43244": 2,
+         "43245": {
+           "serialNumber": "newSerialNumber",
+           "qty": 5
+         }
+       }
+     }
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+Response is explained in the [Create Shipment Response](create-shipment-response).
+
+## Response example
+
+```json
+ {
+     "status": "ok",
+     "shipment": {
+       "orderId": "83651",
+       "selectionId": "ff805e6dc70f905553e2225c6977a27a",
+       "orderDate": "2012-02-04 15:16:13",
+       "cancelDate": "2012-08-04 15:16:13",
+       "preferredDeliveryDate": "2012-05-04 15:16:13",
+       "estimatedDeliveryDate": "2012-05-04 15:16:13",
+       "orderStore": "retail",
+       "orderCurrency": "EUR",
+       "shipmentId": "83651-1",
+       "customerId": "11627",
+       "accountId": "0",
+       "deliveryName": "Someones Name",
+       "deliveryCompany": "",
+       "deliveryEmail": "tetete@ttet.com",
+       "deliveryCell": "+4912345678",
+       "deliveryTele": "",
+       "deliveryAddress": "Examplestreet 1",
+       "deliveryCoaddress": "",
+       "deliveryZipcode": "12345",
+       "deliveryCity": "Somecity",
+       "deliveryState": "",
+       "deliveryCountry": "DE",
+       "billingVAT": "",
+       "poNumber": "",
+       "shippingList": "standard",
+       "proforma": "http://.../proforma?shipment=83651-1",
+       "deliveryNote": "http://../delnote?shipment=83651-1",
+       "invoices": [
+         "https://online.klarna.com/invoice_public_show.yaws/invoice.pdf?invno=<>&orgno="
+       ],
+       "suspect": 0,
+       "hold": 0,
+       "paid": 1,
+       "shouldCapture": 0,
+       "shippingValue": 25,
+       "voucherValue": 0,
+       "grandTotalValue": 3978.75,
+       "grandTotalTaxValue": 795.75,
+       "internalComment": "",
+       "otherComment": "",
+       "products": [
+         {
+           "lineId": "43243",
+           "sku": "B405916999",
+           "variantSku": "",
+           "sizeSku": "",
+           "name": "Product #1",
+           "variant": "White",
+           "size": "XS",
+           "ean": "7332577534606",
+           "qty": 1,
+           "originalPrice": 500.5,
+           "price": 450.5,
+           "weight": 2,
+           "weightUnit": "kg",
+           "countryOfOrigin": "DE",
+           "harmCode": "345345435",
+           "comment": ""
+         },
+         {
+           "lineId": "43244",
+           "sku": "C00622469B",
+           "variantSku": "",
+           "sizeSku": "",
+           "name": "Product #2",
+           "variant": "Blue",
+           "size": "XS",
+           "ean": "7332577652942",
+           "qty": 2,
+           "originalPrice": 200.5,
+           "price": 180.5,
+           "weight": 1.5,
+           "weightUnit": "kg",
+           "countryOfOrigin": "CI",
+           "harmCode": "423432",
+           "comment": ""
+         }
+       ]
+     }
+   }
+```
+
+
+
+## Error example
+
+```json
+   {
+     "status": "no",
+     "msg": "shipment is sent and can not be updated",
+     "shipment": "4-1"
+   }
+```
+
+```json
+  {
+     "status": "no",
+     "msg": "shipment is paid and can not be updated",
+     "shipment": "4-1"
+   }
+```
+
+```json
+  {
+     "status": "no",
+     "msg": "shipment is captured and can not be updated",
+     "shipment": "4-1"
+   }
+```
+
+```json
+  {
+     "status": "no",
+     "msg": "shipment has refunds and can not be updated", 
+     "shipment": "4-1"
+   }
+```

--- a/pages/05.api-references/04.order-api/01.api-reference/805.update-stock/docs.md
+++ b/pages/05.api-references/04.order-api/01.api-reference/805.update-stock/docs.md
@@ -1,0 +1,158 @@
+---
+title: Order API -  Update stock
+altTitle: Update stock
+excerpt: This function is designed for creation and modification of new shipments.
+taxonomy:
+  category: docs
+---
+
+# Update stock
+
+```text
+PUT  *base*/stock
+```
+
+This updates the `physicalStock` quantities in Centra. This is the number of products in stock including those that are reserved for orders.
+
+[notice-box=alert]
+You cannot set the quantity below the number that is reserved for orders, the value specified in ``allocatedStock`` from :ref:`Get stock <order-api-get-stock>`. In the case the stock update contains a lower amount than the allocated stock, Centra will set the quantity to ``allocatedStock`` which the lowest possible value without affecting any reserved orders.
+
+The request will not return any error message, but an email notification can be sent to a Centra-administrator from the plugin settings.
+[/notice-box]
+
+
+## Parameters
+
+[parameter data="products" datatype="array" isRequired=true sublevel=1]
+Array of products to update stock on
+[/parameter]
+
+[parameter data="product" datatype="string" isRequired=true sublevel=2]
+String to update a product item. Use ``ean`` or a combination of ``sku``, ``variantSku`` and ``sizeSku`` to update the quantity for each product.
+[/parameter]
+
+[parameter data="quantity" datatype="int" isRequired=true sublevel=2]
+The quantity of the physical stock for the item.
+[/parameter]
+
+[parameter data="costPrice" datatype="string" isRequired=false sublevel=2]
+The internal cost price for this item.
+[/parameter]
+
+[parameter data="costPriceCurrency" datatype="string" isRequired=false sublevel=2]
+ISO code for the currency for the cost price. ``USD``, ``EUR``, ``SEK``, etc.
+[/parameter]
+
+[parameter data="xml" datatype="boolean" isRequired=false sublevel=1]
+Response in xml format instead of json.
+[/parameter]
+
+## Request example
+The example above uses EAN, this is the same field as the [Get stock](get-stock) product field `ean`. The example below uses SKU by combining the [Get stock](get-stock) fields `sku`, `variantSku` and `sizeSku`:
+
+```http
+   POST <base>/stock HTTP/1.1
+   Content-type: application/json
+
+   {
+     "products": [
+       {
+         "product": "1234567890123",
+         "quantity": 54
+       },
+       {
+         "product": "9876543210123",
+         "quantity": 55
+       },
+       {
+         "product": "5432167890123",
+         "quantity": 1
+       }
+     ]
+   }
+```
+
+Optionally you can also include a cost / pcs value for the items.
+
+```http
+   POST <base>/stock HTTP/1.1
+   Content-type: application/json
+
+   {
+     "products":[
+       {
+         "product": "1234567890123",
+         "quantity": 54,
+         "costPrice": 12.54,
+         "costPriceCurrency": "SEK"
+       },
+       {
+         "product": "9876543210123",
+         "quantity": 55,
+         "costPrice": 8.12,
+         "costPriceCurrency": "EUR"
+       },
+       {
+         "product": "5432167890123",
+         "quantity": 1,
+         "costPrice": 54.24,
+         "costPriceCurrency": "USD"
+       }
+     ]
+   }
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="msg" datatype="string" isRequired=false sublevel=1]
+If ``status`` returns ``no``, this value should send back a message why it failed.
+[/parameter]
+
+[parameter data="errors" datatype="object" isRequired=false sublevel=1]
+If ``status`` returns ``no``, this object might contain information about products that could not be updated.
+[/parameter]
+
+[parameter data="productsNotFound" datatype="array of string" isRequired=false sublevel=2]
+This will be an array with the product identifiers that could not be updated from the request.
+
+Like this: ``["43242342", "43243294", "432432232"]``
+[/parameter]
+
+[parameter data="productsAreBundles" datatype="array of string" isRequired=false sublevel=2]
+This will be an array with the product identifiers that are bundled products. This means that they can not be updated directly, since they are based on products the bundle is connected to.
+
+Like this: ``["43242342", "43243294", "432432232"]``
+[/parameter]
+
+
+## Response example
+
+```json
+    {
+      "status":"ok"
+    }
+```
+
+
+
+## Error example
+
+```json
+   {
+       "status": "no",
+       "msg": "Some of the products were not updated",
+       "errors": {
+         "productsNotFound": [
+           "9876543210123",
+           "5432167890123"
+         ]
+       }
+     }
+```
+

--- a/pages/05.api-references/08.subscription-api/01.api-reference/101.create-subscription/docs.md
+++ b/pages/05.api-references/08.subscription-api/01.api-reference/101.create-subscription/docs.md
@@ -1,0 +1,201 @@
+---
+title: Subscription API - Create subscription
+altTitle: Create subscription
+excerpt: Add a subscription with payment details, will not be completed/registered as a completed subscription until `subscription/payment` has been called.
+taxonomy:
+  category: docs
+---
+
+# Create subscription
+
+```text
+POST  *base*/subscription/order
+```
+
+Add a subscription with payment details, will not be completed/registered as a completed subscription until `subscription/payment` has been called.
+## Parameters
+
+[parameter data="name sname" datatype="string" isRequired=true sublevel=1]
+First and last name of the customer
+[/parameter]
+
+[parameter data="email" datatype="string" isRequired=true sublevel=1]
+Customer e-mail
+[/parameter]
+
+[parameter data="address coaddress city state zipcode phoneNumber" datatype="string" isRequired=false sublevel=1]
+Address information for the customer
+[/parameter]
+
+[parameter data="language" datatype="string" isRequired=false sublevel=1]
+The language code for created customer.
+[/parameter]
+
+[parameter data="country" datatype="string" isRequired=true  sublevel=1]
+The country of the customer. ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc)
+[/parameter]
+
+[parameter data="package" datatype="array" isRequired=true sublevel=1]
+Array with Package IDs for each package you want in the subscription.
+
+For example: ``package[]=3232&package[]=4344``
+[/parameter]
+
+[parameter data="payment" datatype="string" isRequired=true sublevel=1]
+URI of payment plugin to be used. Needs to be set up before as a payment plugin for the store.
+
+.. note:: There are only a few payment plugins that supports subscription services. Please make sure the payment plugin you set up allows it.
+[/parameter]
+
+[parameter data="payment_url" datatype="string" isRequired=false sublevel=1]
+A url where the customer should be redirected to when payment is completed.
+[/parameter]
+
+[parameter data="pnr" datatype="string" isRequired=false sublevel=1]
+The social security number for the user, used for some payment plugins to invoice the customer.
+[/parameter]
+
+[parameter data="sendNewsletter" datatype="boolean" isRequired=false sublevel=1]
+If the user opted in to a newsletter subscription.
+[/parameter]
+
+[parameter data="startdate" datatype="datetime" isRequired=false sublevel=1]
+Default ``today``. The date when the subscription should start. The first order will be created first after this date.
+[/parameter]
+
+[parameter data="interval" datatype="int" isRequired=false sublevel=1]
+Default ``14``. The interval between each subscription. Depending on `intervaltype` it will be months or days.
+[/parameter]
+
+[parameter data="intervaltype" datatype="enum" isRequired=false sublevel=1]
+Default ``D``. The type of interval for the subscription.
+
+* ``M`` interval is in months.
+* ``D`` interval is in days.
+[/parameter]
+
+[parameter data="consent" datatype="object" isRequired=false sublevel=1]
+A list of consents the customer agreed to. The ``key`` of each item in the object is the key for the consent. If the consent key does not exists already, it will be added automatically.
+
+For example like this: ``consent[newsletter_consent][consent_name]=boop``
+[/parameter]
+
+[parameter data="consent_name" datatype="string" sublevel=2]
+The name of the consent.
+[/parameter]
+
+[parameter data="consent_text" datatype="string" sublevel=2]
+The description of the consent.
+[/parameter]
+
+[parameter data="consent_version" datatype="string" sublevel=2]
+The version of the consent.
+[/parameter]
+
+[parameter data="consent_language" datatype="string" sublevel=2]
+The language of the consent. No validation is made on this field for the formatting of the language code.
+[/parameter]
+
+
+## Request example
+
+```http
+    POST <base>/subscription/order HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+    
+    name=Kalle&sname=Anka&address=Paradisäppelvägen+9&
+    coaddress=&city=Ankeborg&state=&zipcode=12345&
+    country=SE&email=kalle.anka@example.com&package[]=1&package[]=3&
+    payment=nets[&pnr=880101-7845]&
+    language=SV
+```
+
+Example Request with consents:
+
+```http
+    POST <base>/subscription/order? HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+    
+    name=Kalle&sname=Anka&address=Paradisäppelvägen+9&coaddress=&
+    city=Ankeborg&state=&zipcode=12345&country=SE&
+    email=kalle.anka@example.com&package[]=1&package[]=3&
+    payment=nets[&payment_url=https://...][&pnr=880101-7845]&
+    language=SV&
+    consent[direct_marketing]=1&
+    consent_name[direct_marketing]=Direct%20Marketing&
+    consent_version[direct_marketing]=1.1&
+    consent[newsletter]=1&consent_name[newsletter]=Newsletter&
+    consent_version[newsletter]=v2&consent_language[newsletter]=sv_SE
+```
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+ ``ok`` if success, else a message explaining what went wrong.
+[/parameter]
+
+[parameter data="id" datatype="int" isRequired=true sublevel=1]
+The ID of the subscription that was created.
+[/parameter]
+
+[parameter data="payment" datatype="object" sublevel=1]
+A payment object with information on how finalize the payment.
+[/parameter]
+
+[parameter data="url" datatype="string" sublevel=2]
+A URL to redirect the user to. This could be to an external payment provider depending on the payment plugin.
+[/parameter]
+
+[parameter data="value" datatype="string" sublevel=2]
+The total value of the subscription.
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+The currency that the subscription was registered with, ``SEK``, ``USD``, ``EUR``, etc.
+[/parameter]
+
+[parameter data="msg" datatype="string" isRequired=false sublevel=1]
+If ``status`` returns ``no``, this value should send back a message why it failed.
+[/parameter]
+
+## Response examples
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+    {
+     "status": "ok",
+     "id": 3,
+     "payment": {
+       "url": "https://...",
+       "value": "123.50",
+       "currency": "SEK"
+     }
+    }
+```
+
+## Error example
+
+```json
+   {
+     "status": "Could not register customer",
+     "error": true,
+     "errors": [
+       "email",
+       "payment"
+     ]
+   }
+```
+
+Bad payment method:
+
+```json
+   {
+        "status": "Bad Payment Method",
+        "error": true,
+        "message": "Error message"
+  }
+```
+

--- a/pages/05.api-references/08.subscription-api/01.api-reference/102.get-packages/docs.md
+++ b/pages/05.api-references/08.subscription-api/01.api-reference/102.get-packages/docs.md
@@ -1,0 +1,113 @@
+---
+title: Subscription API - Get packages
+altTitle: Get packages
+excerpt: Receive a list of all the active packages and their price in the provided pricelist.
+taxonomy:
+  category: docs
+---
+
+# Get packages
+
+```text
+GET  *base*/subscription/packages
+```
+
+Receive a list of all the active packages and their price in the provided pricelist.
+## Parameters
+
+[parameter data="pricelist" datatype="string" isRequired=true sublevel=1]
+Name of pricelist to list packages for.
+[/parameter]
+
+## Request example
+
+```http
+    GET <base>/subscription/packages?pricelist=SEK HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="packages" datatype="array" isRequired=true sublevel=1]
+List of all packages in the selected currency.
+[/parameter]
+
+[parameter data="id" datatype="int" isRequired=true sublevel=2]
+ID of the package
+[/parameter]
+
+[parameter data="name" datatype="string" sublevel=2]
+Name of the package
+[/parameter]
+
+[parameter data="price" datatype="string" sublevel=2]
+Price amount for the package
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+Currency code for the package. ``SEK``, ``USD``, ``EUR``, etc.
+[/parameter]
+
+[parameter data="products" datatype="array" sublevel=2]
+Array of products inside the package.
+[/parameter]
+
+[parameter data="id" datatype="int" sublevel=3]
+ID of the product
+[/parameter]
+
+[parameter data="size" datatype="string" sublevel=3]
+Size name of the product selected in the package.
+[/parameter]
+
+[parameter data="variant" datatype="string" sublevel=3]
+Variant name of the product selected in the package.
+[/parameter]
+
+[parameter data="product" datatype="string" sublevel=3]
+Product name
+[/parameter]
+
+## Response examples
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+{
+     "packages": [
+       {
+         "id": 1,
+         "name": "Super Package 5000",
+         "price": "123.50",
+         "currency": "SEK",
+         "products": [
+           {
+             "id": "1",
+             "size": "S",
+             "variant": "Red",
+             "product": "T-shirt"
+           }
+         ]
+       },
+       {
+         "id": 2,
+         "name": "Super Package 10000",
+         "price": "246.50",
+         "currency": "SEK",
+         "products": [
+           {
+             "id": "1",
+             "size": "L",
+             "variant": "Red",
+             "product": "T-shirt"
+           }
+         ]
+       }
+     ]
+   }
+```
+
+

--- a/pages/05.api-references/08.subscription-api/01.api-reference/103.get-subscription/docs.md
+++ b/pages/05.api-references/08.subscription-api/01.api-reference/103.get-subscription/docs.md
@@ -1,0 +1,164 @@
+---
+title: Subscription API - Get subscription
+altTitle: Get subscription
+excerpt: Return subscription by specified id.
+taxonomy:
+  category: docs
+---
+
+# Get subscription
+
+```text
+GET  *base*/subscription/subscriptions/*id*
+```
+
+Return subscription by specified id.
+
+## Parameters
+
+[parameter data="customerId" datatype="string" isRequired=true sublevel=1]
+Customer id.
+[/parameter]
+
+## Request example
+
+```http
+    GET <base>/subscription/1 HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+ ``ok`` if success, else a message explaining what went wrong.
+[/parameter]
+
+[parameter data="subscriptions" datatype="array" isRequired=true sublevel=1]
+List of subscriptions
+[/parameter]
+
+[parameter data="status" datatype="string" isRequired=true sublevel=2]
+The status of the subscription.
+[/parameter]
+
+[parameter data="id" datatype="int" isRequired=true sublevel=2]
+The ID of the subscription.
+[/parameter]
+
+[parameter data="amount" datatype="decimal2 (0.00)" isRequired=true sublevel=2]
+The total value of the subscription.
+[/parameter]
+
+
+[parameter data="shipping" datatype="decimal2 (0.00)" sublevel=2]
+The shipping value of the subscription.
+[/parameter]
+
+[parameter data="itemCount" datatype="int" sublevel=2]
+The total amount of products in the subscription.
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+The currency that the subscription was registered with, ``SEK``, ``USD``, ``EUR``, etc.
+[/parameter]
+
+[parameter data="address" datatype="object" sublevel=2]
+An address object with the customer information.
+[/parameter]
+
+[parameter data="firstName lastName" datatype="string" sublevel=3]
+The name of the customer.
+[/parameter]
+
+[parameter data="address coaddress city state zipcode phoneNumber" datatype="string" sublevel=3]
+The customer's address information.
+[/parameter]
+
+[parameter data="country" datatype="string" sublevel=3]
+The country of the customer. ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc)
+[/parameter]
+
+[parameter data="createdAt" datatype="string" sublevel=3]
+The date in ``Y-m-d H-i-s`` format when the subscription was created.
+[/parameter]
+
+[parameter data="startDate" datatype="string" sublevel=3]
+The date in ``Y-m-d`` format when the subscription starts.
+[/parameter]
+
+[parameter data="nextOrderDate" datatype="string" sublevel=3]
+The date in ``Y-m-d`` format when the subscription has next shipping.
+[/parameter]
+
+[parameter data="interval" datatype="int" sublevel=3]
+The interval between each subscription. Depending on `intervaltype` it will be months or days.
+[/parameter]
+
+[parameter data="intervalType" datatype="string" sublevel=3]
+The type of interval for the subscription
+* ``Month`` interval is in months.
+* ``Day`` interval is in days.        
+[/parameter]
+
+[parameter data="pricelist" datatype="string" sublevel=3]
+Subscription price list id.      
+[/parameter]
+
+[parameter data="packages" datatype="array" sublevel=3]
+List of subscription packages. Contains packages IDs.   
+[/parameter]
+
+[parameter data="customer" datatype="string" sublevel=3]
+Subscription customer id   
+[/parameter]
+
+## Response examples
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+    {
+     "status": "ok",
+     "subscriptions": [
+       {
+         "status": "active",
+         "id": 3,
+         "amount": "900.00",
+         "shipping": "20.00",
+         "itemCount": 2,
+         "currency": "SEK",
+         "createdAt": "2020-05-05 15:00:00",
+         "startDate": "2020-05-05",
+         "nextOrderDate": "2020-05-06",
+         "interval": 14,
+         "intervalType": "Day",
+         "pricelist": "19",
+         "packages": ["1"],
+         "address": {
+           "firstName": "Kalle",
+           "lastName": "Anka",
+           "phoneNumber": "+4687203333",
+           "address1": "Malarvarvsbacken 8",
+           "address2": "c/o Young Skilled AB",
+           "zipCode": "11733",
+           "city": "Stockholm",
+           "state": "",
+           "country": "SE"
+         },
+         "customer": "132",
+       }
+     ]
+   }
+```
+
+## Error examples
+
+```json
+   {
+     "status": "Subscription not found",
+     "error": true
+   }
+```

--- a/pages/05.api-references/08.subscription-api/01.api-reference/104.get-subscriptions/docs.md
+++ b/pages/05.api-references/08.subscription-api/01.api-reference/104.get-subscriptions/docs.md
@@ -1,0 +1,184 @@
+---
+title: Subscription API - Get subscriptions
+altTitle: Get subscriptions
+excerpt: Receive a list of all subscriptions for the customer.
+taxonomy:
+  category: docs
+---
+
+# Get subscriptions
+
+```text
+GET  *base*/subscription/subscriptions?customerEmail=*email*
+```
+
+Receive a list of all subscriptions for the customer.
+
+## Parameters
+
+[parameter data="customerEmail" datatype="string" isRequired=true sublevel=1]
+Customer email address
+[/parameter]
+
+## Request example
+
+```http
+    POST <base>/subscription/order HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+    
+GET <base>/subscription?customerEmail=example@centra.com HTTP/1.1
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else ``no``.
+[/parameter]
+
+[parameter data="subscriptions" datatype="array" isRequired=true sublevel=1]
+List of subscriptions
+[/parameter]
+
+[parameter data="status" datatype="string" isRequired=true sublevel=2]
+The status of the subscription.
+[/parameter]
+
+[parameter data="id" datatype="int" isRequired=true sublevel=2]
+The ID of the subscription.
+[/parameter]
+
+[parameter data="amount" datatype="decimal2 (0.00)" isRequired=true sublevel=2]
+The total value of the subscription.
+[/parameter]
+
+
+[parameter data="shipping" datatype="decimal2 (0.00)" sublevel=2]
+The shipping value of the subscription.
+[/parameter]
+
+[parameter data="itemCount" datatype="int" sublevel=2]
+The total amount of products in the subscription.
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+The currency that the subscription was registered with, ``SEK``, ``USD``, ``EUR``, etc.
+[/parameter]
+
+[parameter data="address" datatype="object" sublevel=2]
+An address object with the customer information.
+[/parameter]
+
+[parameter data="firstName lastName" datatype="string" sublevel=3]
+The name of the customer.
+[/parameter]
+
+[parameter data="address coaddress city state zipcode phoneNumber" datatype="string" sublevel=3]
+The customer's address information.
+[/parameter]
+
+[parameter data="country" datatype="string" sublevel=3]
+The country of the customer. ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc)
+[/parameter]
+
+[parameter data="createdAt" datatype="string" sublevel=3]
+The date in ``Y-m-d H-i-s`` format when the subscription was created.
+[/parameter]
+
+[parameter data="startDate" datatype="string" sublevel=3]
+The date in ``Y-m-d`` format when the subscription starts.
+[/parameter]
+
+[parameter data="nextOrderDate" datatype="string" sublevel=3]
+The date in ``Y-m-d`` format when the subscription has next shipping.
+[/parameter]
+
+[parameter data="interval" datatype="int" sublevel=3]
+The interval between each subscription. Depending on `intervaltype` it will be months or days.
+[/parameter]
+
+[parameter data="intervalType" datatype="string" sublevel=3]
+The type of interval for the subscription
+* ``Month`` interval is in months.
+* ``Day`` interval is in days.        
+[/parameter]
+
+[parameter data="pricelist" datatype="string" sublevel=3]
+Subscription price list id.      
+[/parameter]
+
+[parameter data="packages" datatype="array" sublevel=3]
+List of subscription packages. Contains packages IDs.   
+[/parameter]
+
+[parameter data="customer" datatype="string" sublevel=3]
+Subscription customer id   
+[/parameter]
+
+## Response examples
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+     {
+        "status": "ok",
+        "subscriptions": [
+          {
+            "status": "active",
+            "id": 3,
+            "amount": "900.00",
+            "shipping": "20.00",
+            "itemCount": 2,
+            "currency": "SEK",
+            "createdAt": "2020-05-05 15:00:00",
+            "startDate": "2020-05-05",
+            "nextOrderDate": "2020-05-06",
+            "interval": 14,
+            "intervalType": "Day",
+            "pricelist": "19",
+            "packages": ["1"],
+            "address": {
+              "firstName": "Kalle",
+              "lastName": "Anka",
+              "phoneNumber": "+4687203333",
+              "address1": "Malarvarvsbacken 8",
+              "address2": "c/o Young Skilled AB",
+              "zipCode": "11733",
+              "city": "Stockholm",
+              "state": "",
+              "country": "SE"
+            },
+            "customer": "132"
+          },
+          {
+            "status": "paused",
+            "id": 4,
+            "amount": "500.00",
+            "shipping": "20.00",
+            "itemCount": 1,
+            "currency": "SEK",
+            "createdAt": "2020-04-03 12:00:00",
+            "startDate": "2020-04-03",
+            "nextOrderDate": "2020-04-04",
+            "interval": 14,
+            "intervalType": "Day",
+            "pricelist": "19",
+            "packages": ["1"],
+            "address": {
+              "firstName": "Kalle",
+              "lastName": "Anka",
+              "phoneNumber": "+4687203333",
+              "address1": "Malarvarvsbacken 8",
+              "address2": "c/o Young Skilled AB",
+              "zipCode": "11733",
+              "city": "Stockholm",
+              "state": "",
+              "country": "SE"
+            },
+            "customer": "132"
+          }
+        ]
+      }
+```

--- a/pages/05.api-references/08.subscription-api/01.api-reference/105.register-payment/docs.md
+++ b/pages/05.api-references/08.subscription-api/01.api-reference/105.register-payment/docs.md
@@ -1,0 +1,157 @@
+---
+title: Subscription API - Register payment
+altTitle: Register payment
+excerpt: This will complete the subscription. Often called when user comes back to payment_url from /subscription/order. All GET/POST-params sent by the payment plugin needs to be attached to this call.
+taxonomy:
+  category: docs
+---
+
+# Register payment
+
+```text
+POST  *base*/subscription/payment
+```
+
+This will complete the subscription. Often called when user comes back to payment_url from /subscription/order. All GET/POST-params sent by the payment plugin needs to be attached to this call.
+
+## Parameters
+
+[parameter data="id" datatype="string" isRequired=true sublevel=1]
+The subscription ID from :doc:`Create Subscription </reference/stable/subscription-api/create-subscription>`
+[/parameter]
+
+[parameter data="payment" datatype="string" isRequired=true sublevel=1]
+URI of payment plugin to be used. Needs to be set up before as a payment plugin for the store.
+[/parameter]
+
+[parameter data="all provider GET/POST params " datatype="any" isRequired=true sublevel=1]
+Attach all GET/POST parameters sent from the payment provider to the ``payment_url`` from :doc:`Create Subscription </reference/stable/subscription-api/create-subscription>`. These will be used to validate if the payment was successful.
+[/parameter]
+## Request example
+
+```http
+    POST <base>/subscription/payment HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+    
+    id=3&payment=nets&[+all GET/POST params sent by payment provider]
+
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+ ``ok`` if success, else a message explaining what went wrong.
+[/parameter]
+
+[parameter data="id" datatype="int" isRequired=true sublevel=1]
+The ID of the subscription that was created.
+[/parameter]
+
+[parameter data="amount" datatype="decimal2 (0.00)" isRequired=true sublevel=2]
+The total value of the subscription.
+[/parameter]
+
+[parameter data="shipping" datatype="decimal2 (0.00)" sublevel=2]
+The shipping value for the first order of the subscription.
+[/parameter]
+
+[parameter data="itemCount" datatype="int" sublevel=2]
+The total amount of products in the subscription.
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+The currency that the subscription was registered with, ``SEK``, ``USD``, ``EUR``, etc.
+[/parameter]
+
+[parameter data="address" datatype="object" sublevel=2]
+An address object with the customer information.
+[/parameter]
+
+[parameter data="firstName lastName" datatype="string" sublevel=3]
+The name of the customer.
+[/parameter]
+
+[parameter data="address coaddress city state zipcode phoneNumber" datatype="string" sublevel=3]
+The customer's address information.
+[/parameter]
+
+[parameter data="country" datatype="string" sublevel=3]
+The country of the customer. ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc)
+[/parameter]
+
+[parameter data="createdAt" datatype="string" sublevel=2]
+The date in ``Y-m-d H-i-s`` format when the subscription was created.
+[/parameter]
+
+[parameter data="startDate" datatype="string" sublevel=2]
+The date in ``Y-m-d`` format when the subscription starts.
+[/parameter]
+
+[parameter data="nextOrderDate" datatype="string" sublevel=2]
+The date in ``Y-m-d`` format when the subscription has next shipping.
+[/parameter]
+
+[parameter data="interval" datatype="int" sublevel=2]
+The interval between each subscription. Depending on `intervaltype` it will be months or days.
+[/parameter]
+
+[parameter data="intervalType" datatype="string" sublevel=2]
+The type of interval for the subscription
+* ``Month`` interval is in months.
+* ``Day`` interval is in days.        
+[/parameter]
+
+[parameter data="receipt" datatype="string" sublevel=2]
+Html snippet that contains a receipt for a subscription payment. Is not null for Klarna payments.  
+[/parameter]
+
+[parameter data="error" datatype="boolean" sublevel=2]
+If ``true``, the payment was not successful. The ``status`` should contain information on why. 
+[/parameter]
+
+## Response examples
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+      {
+         "status": "ok",
+         "id": 3,
+         "amount": "900.00",
+         "shipping": "20.00",
+         "itemCount": 2,
+         "currency": "SEK",
+         "address": {
+           "firstName": "Kalle",
+           "lastName": "Anka",
+           "phoneNumber": "+4687203333",
+           "address1": "Malarvarvsbacken 8",
+           "address2": "c/o Young Skilled AB",
+           "zipCode": "11733",
+           "city": "Stockholm",
+           "state": "",
+           "country": "SE"
+         },
+         "createdAt": "2020-05-05 15:00:00",
+         "startDate": "2020-05-05",
+         "nextOrderDate": "2020-05-06",
+         "interval": 14,
+         "intervalType": "Day",
+         "receipt": "<div>...</div>"
+       }
+```
+
+## Error example
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+    {
+      "status": "Could not register customer",
+      "error": true
+    }
+```

--- a/pages/05.api-references/08.subscription-api/01.api-reference/106.update-subscription/docs.md
+++ b/pages/05.api-references/08.subscription-api/01.api-reference/106.update-subscription/docs.md
@@ -1,0 +1,197 @@
+---
+title: Subscription API - Update subscription
+altTitle: Update subscription
+excerpt: Update a subscription.
+taxonomy:
+  category: docs
+---
+
+# Update subscription
+
+```text
+PUT  *base*/subscription/subscription/*id*
+```
+
+Update a subscription.
+
+## Parameters
+
+[parameter data="status" datatype="enum" isRequired=false sublevel=1]
+Subscription status
+       * ``active`` Subscription is active.
+       * ``paused`` Subscription is paused.
+       * ``cancelled`` Subscription is cancelled.
+[/parameter]
+
+## Request example
+
+```http
+    PUT *base*/subscription/subscription/*id* HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded
+    
+    status=active
+```
+
+## Response
+
+`200` `Content-type: application/json`
+
+[parameter data="status" datatype="string" isRequired=true sublevel=1]
+``ok`` if success, else a message explaining what went wrong.
+[/parameter]
+
+[parameter data="subscriptions" datatype="array" isRequired=true sublevel=1]
+List of subscriptions
+[/parameter]
+
+[parameter data="status" datatype="string" isRequired=true sublevel=2]
+The status of the subscription.
+[/parameter]
+
+[parameter data="id" datatype="int" isRequired=true sublevel=2]
+The ID of the subscription.
+[/parameter]
+
+[parameter data="amount" datatype="decimal2 (0.00)" isRequired=true sublevel=2]
+The total value of the subscription.
+[/parameter]
+
+[parameter data="shipping" datatype="decimal2 (0.00)" sublevel=2]
+The shipping value of the subscription.
+[/parameter]
+
+[parameter data="itemCount" datatype="int" sublevel=2]
+The total amount of products in the subscription.
+[/parameter]
+
+[parameter data="currency" datatype="string" sublevel=2]
+The currency that the subscription was registered with, ``SEK``, ``USD``, ``EUR``, etc.
+[/parameter]
+
+[parameter data="address" datatype="object" sublevel=2]
+An address object with the customer information.
+[/parameter]
+
+[parameter data="firstName lastName" datatype="string" sublevel=3]
+The name of the customer.
+[/parameter]
+
+[parameter data="address coaddress city state zipcode phoneNumber" datatype="string" sublevel=3]
+The customer's address information.
+[/parameter]
+
+[parameter data="country" datatype="string" sublevel=3]
+The country of the customer. ISO-Alpha-2 (``SE``, ``US``, ``GB`` etc)
+[/parameter]
+
+[parameter data="createdAt" datatype="string" sublevel=3]
+The date in ``Y-m-d H-i-s`` format when the subscription was created.
+[/parameter]
+
+[parameter data="startDate" datatype="string" sublevel=3]
+The date in ``Y-m-d`` format when the subscription starts.
+[/parameter]
+
+[parameter data="nextOrderDate" datatype="string" sublevel=3]
+The date in ``Y-m-d`` format when the subscription has next shipping.
+[/parameter]
+
+[parameter data="interval" datatype="int" sublevel=3]
+The interval between each subscription. Depending on `intervaltype` it will be months or days.
+[/parameter]
+
+[parameter data="intervalType" datatype="string" sublevel=3]
+The type of interval for the subscription
+* ``Month`` interval is in months.
+* ``Day`` interval is in days.        
+[/parameter]
+
+[parameter data="pricelist" datatype="string" sublevel=3]
+Subscription price list id.      
+[/parameter]
+
+[parameter data="packages" datatype="array" sublevel=3]
+List of subscription packages. Contains packages IDs.   
+[/parameter]
+
+[parameter data="customer" datatype="string" sublevel=3]
+Subscription customer id   
+[/parameter]
+
+## Response examples
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+   {
+     "status": "ok",
+     "subscriptions": [
+       {
+         "status": "active",
+         "id": 3,
+         "amount": "900.00",
+         "shipping": "20.00",
+         "itemCount": 2,
+         "currency": "SEK",
+         "createdAt": "2020-05-05 15:00:00",
+         "startDate": "2020-05-05",
+         "nextOrderDate": "2020-05-06",
+         "interval": 14,
+         "intervalType": "Day",
+         "pricelist": "19",
+         "packages": ["1"],
+         "address": {
+           "firstName": "Kalle",
+           "lastName": "Anka",
+           "phoneNumber": "+4687203333",
+           "address1": "Malarvarvsbacken 8",
+           "address2": "c/o Young Skilled AB",
+           "zipCode": "11733",
+           "city": "Stockholm",
+           "state": "",
+           "country": "SE"
+         },
+         "customer": "132"
+       }
+     ]  
+   }
+```
+
+## Error example
+
+Subscription not found:
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+   {
+     "status": "Subscription not found",
+     "error": true
+   }
+```
+
+Invalid subscription status:
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+   {
+     "status": "Invalid status provided",
+     "error": true
+   }
+```
+
+Restore cancelled subscription error:
+
+```http
+   HTTP/1.1 200 OK
+   Content-type: application/json
+
+   {
+     "status": "Cannot restore cancelled subscription",
+     "error": true
+   }
+```

--- a/pages/05.api-references/08.subscription-api/chapter.md
+++ b/pages/05.api-references/08.subscription-api/chapter.md
@@ -1,0 +1,15 @@
+---
+title: Subscription API
+altTitle: Subscription API
+excerpt: The Subscription API is used for recurring sales where the orders are created automatically using a specified subscription period. Using the API you are able to create new subscriptions that will authorize the payment provider and enable orders to be created.
+taxonomy:
+  category: docs
+---
+
+# API Reference
+
+The Subscription API is used for recurring sales where the orders are created automatically using a specified subscription period. Using the API you are able to create new subscriptions that will authorize the payment provider and enable orders to be created.
+
+## Authentication
+
+The `<base>` mentioned in the API-reference is the location of the plugin URL when installing the subscription plugin. The `secret` set up inside the plugin should be appended to every API-url using `?secret=xyz`.


### PR DESCRIPTION
Migrate documentation from old dev [old dev](https://docs.centra.com/reference/stable/index) to [new one](https://centra-api-documentation-demo.herokuapp.com/api-references/),

- Finished [Order API ](https://github.com/centrahq/api-documentation/tree/master/source/reference/stable) (list-customers and till end);
- Subscription API migration;
- Fixed miss-leading 'status' description;


