### PR TITLE
Fixed: one space too little

### DIFF
--- a/source/reference/stable/order-api/get-voucher.md
+++ b/source/reference/stable/order-api/get-voucher.md
@@ -122,7 +122,7 @@ Return active/inactive voucher by specified Id. Cancelled vouchers are ignored.
 
             - Value of the voucher for each price list. Contains id of price list to value. Exists for `priceoff` voucher type
 
-         * - ``freeShipping``
+          * - ``freeShipping``
 
               .. type:: bool
 


### PR DESCRIPTION
Docs are not building because of

```
...../api-documentation/source/reference/stable/order-api/get-voucher.md:18:Error parsing content block for the "list-table" directive: exactly one bullet list expected.
```

One space was missing.