### PR TITLE
fix: change [warning] type to [alert] for notice boxes

### DIFF
--- a/pages/01.overview/06.taxes/docs.md
+++ b/pages/01.overview/06.taxes/docs.md
@@ -20,7 +20,7 @@ Tax Rules control what amount of tax should be applied based on Country and Cust
 
 For each Tax Rule you can also configure if the prices in your Store should be displayed with or without tax and whether or not to apply tax to the handling and shipping fees (which is enabled by default). Finally, for countries in which tax amount depends on the state (like US, Canada or Australia), you can select to apply tax per ship-to country **and** state, in which case you will need to create separate Rules for each of the tax rates and apply them to appropriate states. It's even possible to configure tax rules applying per specific zip codes, which is sometimes used for US taxes.
 
-[notice-box=warning]
+[notice-box=alert]
 If you enable a Tax Rule for specific US zip codes, Centra will enable zip code validation for US orders. This means only allowed zip code formats for United States will be: `NNNNN`, `NNNN-NNNNN` or `NNNNNNNNN`. Other formats will return a checkout error and prevent you from finalizing the order. You need to be aware of it and handle this scenario in your front end.
 [/notice-box]
 

--- a/pages/06.plugins/02.stripe-payment-intents/docs.md
+++ b/pages/06.plugins/02.stripe-payment-intents/docs.md
@@ -24,7 +24,9 @@ When the address is changed in the browser popup an event will still be sent to 
 
 ![stripe-pi-currency-change.png](stripe-pi-currency-change.png)
 
-[notice-box=warning]This makes it really important that the proper country is selected before the payment button is launched, as any address that requires the currency to change will get this error. We recommend always having the country selector as the first step in the checkout, to make sure the proper currency is set.[/notice-box]
+[notice-box=alert]
+This makes it really important that the proper country is selected before the payment button is launched, as any address that requires the currency to change will get this error. We recommend always having the country selector as the first step in the checkout, to make sure the proper currency is set.
+[/notice-box]
 
 This restriction might change in the future if the Payment Request API will support changing currency.
 

--- a/pages/06.plugins/06.adyen-drop-in/docs.md
+++ b/pages/06.plugins/06.adyen-drop-in/docs.md
@@ -99,7 +99,9 @@ There's more information about how to get your Client key in the [documentation 
 
 The `Notification URL` is used for the Server Communication from Adyen.
 
-[notice-box=warning]You should set a Server communication URL for each Merchant Account you have. Make sure you have selected a Merchant Account in Adyen before you add it on the "Server Communication"-page.[/notice-box]
+[notice-box=alert]
+You should set a Server communication URL for each Merchant Account you have. Make sure you have selected a Merchant Account in Adyen before you add it on the "Server Communication"-page.
+[/notice-box]
 
 ![adyen-drop-in-merchant.png](adyen-drop-in-merchant.png)
 

--- a/pages/06.plugins/12.external-payment-plugin/docs.md
+++ b/pages/06.plugins/12.external-payment-plugin/docs.md
@@ -52,8 +52,10 @@ In both ways you need to provide the signature which is base64 encoded HMAC SHA2
 
 The first request (either POST `/payment-result` or push notification) with successful (`success=true`) authorization triggers order creation. If the first authorization to arrive is a failed one it will be accepted by Centra and shown on the order transcation history later, when the order is created.
 
-[notice-box=warning]There is no way to provide or update the customer address using requests finalizing the payment.
-Centra needs to know the customer address before. Not providing the address before might result in invalid orders with empty address.[/notice-box]
+[notice-box=alert]
+There is no way to provide or update the customer address using requests finalizing the payment.
+Centra needs to know the customer address before. Not providing the address before might result in invalid orders with empty address.
+[/notice-box]
 
 
 ###1. Checkout API `POST /payment-result`:
@@ -210,7 +212,9 @@ Example response:
 }
 ```
 
-[notice-box=warning]Only one successful (success=true) authorization and one successful (success=true) capture is allowed per order.[/notice-box]
+[notice-box=alert]
+Only one successful (success=true) authorization and one successful (success=true) capture is allowed per order.
+[/notice-box]
 
 
 ## Captures and refunds:


### PR DESCRIPTION
[Jira](https://centracommerce.atlassian.net/jira/software/projects/WHOLESALE/boards/12?selectedIssue=WHOLESALE-2042)

Notice boxes with `warning`  status is displaying like:
<img width="675" alt="Screen Shot 2021-08-12 at 3 04 56 PM" src="https://user-images.githubusercontent.com/54850073/129201715-1e076b9d-dd44-46af-9554-07166444db5f.png">

So I changed `warning`  status to `alert`, it looks like:
<img width="678" alt="Screen Shot 2021-08-12 at 3 06 19 PM" src="https://user-images.githubusercontent.com/54850073/129201901-5446b42f-6700-4b84-a45c-c60dc675aa3c.png">

