### PR TITLE
Update grav version

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,4 +1,4 @@
-GRAV_VERSION="1.7.17"
+GRAV_VERSION="1.7.26"
 
 # Read auth token from env file
 if [ -f "$ENV_DIR/GITHUB_AUTH_TOKEN" ]; then


### PR DESCRIPTION
`page-toc` plugin requires lates version of Grav

<img width="500" alt="Screen Shot 2022-01-05 at 9 05 33 AM" src="https://user-images.githubusercontent.com/54850073/148183393-87330cf0-8f91-4a11-a2ef-d9f2f6c41056.png">
