### PR TITLE
add notice regarding `product_media` custom attributes

### DIFF
--- a/pages/01.overview/08.custom-attributes/docs.md
+++ b/pages/01.overview/08.custom-attributes/docs.md
@@ -324,6 +324,11 @@ Response from the Checkout API:
 }
 ```
 
+[notice-box=info]
+Unlike other custom attributes, `product_media` attributes doesn't need publishing to show up in the Checkout API.
+[/notice-box]
+
+
 Response from the Shop API:
 
 ```JSON


### PR DESCRIPTION
The `product_media` custom attributes doesn't need publishing under
"Published custom fields" to be exposed in the Checkout API.

**Notice:** I've not previewed these changes [by running locally](https://github.com/centrahq/api-documentation/blob/master/docs/run-locally.md), since i lack access to the [centra-grav-themes](https://github.com/centrahq/centra-grav-themes) repo. 